### PR TITLE
Fix typo in -all description

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -124,6 +124,6 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.Flags().BoolP("all", "a", false, "Display hidden (dotdirs) durectories as well")
+	rootCmd.Flags().BoolP("all", "a", false, "Display hidden (dotdirs) directories as well")
 	rootCmd.Flags().BoolP("version", "v", false, "Display lsx version")
 }


### PR DESCRIPTION
Small PR, but it fixes the grammar error in the `-all` flag description.