### PR TITLE
(install.sh) Set go build output to '$GOPATH' instead of $HOME/go

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ fi
 cp "script/lsx.sh" "$HOME/.config/lsx/lsx.sh"
 
 # build
-go build -o "$HOME/go/bin/ls-x"
+go build -o "$GOPATH/bin/ls-x"
 
 echo "INFO: build successful!"
 


### PR DESCRIPTION
I think `go build -o "$HOME/go/bin/ls-x"` assumes the default `GOPATH` location, and doesn't work if it's set to something else.