### PR TITLE
Fix permissions of config directory

### DIFF
--- a/lsx/lsx.go
+++ b/lsx/lsx.go
@@ -54,7 +54,7 @@ func (app *Lsx) Init() {
 	app.AccessRecordFile = filepath.Join(app.ConfigDir, "access-record.yaml")
 
 	// create configDir if doesn't exist
-	err := os.MkdirAll(app.ConfigDir, 0664)
+	err := os.MkdirAll(app.ConfigDir, 0750)
 	utils.CheckError(err)
 
 	// create alias file , temp file and access record file


### PR DESCRIPTION
A directory with file perms 0664 cannot be cd'ed into.
Needs the exec bit (+x), so we would normally create the directory with the
perms 0755, but we'll use a more secure 0750.